### PR TITLE
Ref #41676 - added hook_living_spaces_group_exclude_permissions() to …

### DIFF
--- a/modules/living_spaces_group/living_spaces_group.module
+++ b/modules/living_spaces_group/living_spaces_group.module
@@ -472,3 +472,12 @@ function living_spaces_group_update_joined_spaces(UserInterface $user) {
   $user->set('joined_spaces', $gids);
   $user->save();
 }
+
+/**
+ * Implements hook_living_spaces_group_exclude_permissions().
+ */
+function living_spaces_group_living_spaces_group_exclude_permissions() {
+  $permissions = ['administer members', 'manage space members'];
+
+  return $permissions;
+}


### PR DESCRIPTION
…remove permission 'manage space members' which are available for office managers.