### PR TITLE
Ref #41661 Added the field 'field_related_space' to message templates…

### DIFF
--- a/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_content_created.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_content_created.default.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.message.group_content_created.field_group_content
+    - field.field.message.group_content_created.field_related_space
     - message.template.group_content_created
+_core:
+  default_config_hash: Sh-DFCI1qYiCuZqUS6614FsTs7vaA_2cNuTrCvKqnY0
 id: message.group_content_created.default
 targetEntityType: message
 bundle: group_content_created
@@ -16,25 +19,35 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_group_content:
-    field_name: field_group_content
+    type: entity_reference_autocomplete
     weight: 11
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    field_name: field_group_content
+  field_related_space:
     type: entity_reference_autocomplete
+    weight: 12
     region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
-    '#group': advanced
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
+    '#group': advanced
 hidden: {  }

--- a/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_content_updated.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_content_updated.default.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.message.group_content_updated.field_group_content
+    - field.field.message.group_content_updated.field_related_space
     - message.template.group_content_updated
+_core:
+  default_config_hash: COMy7AcVXCtPNsu5q0s6fbFBVAgq1cBIeQJXVhsrrpg
 id: message.group_content_updated.default
 targetEntityType: message
 bundle: group_content_updated
@@ -16,25 +19,35 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_group_content:
-    field_name: field_group_content
+    type: entity_reference_autocomplete
     weight: 11
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    field_name: field_group_content
+  field_related_space:
     type: entity_reference_autocomplete
+    weight: 12
     region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
-    '#group': advanced
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
+    '#group': advanced
 hidden: {  }

--- a/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_member_added.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_member_added.default.yml
@@ -4,7 +4,10 @@ dependencies:
   config:
     - field.field.message.group_member_added.field_group_content
     - field.field.message.group_member_added.field_group_label
+    - field.field.message.group_member_added.field_related_space
     - message.template.group_member_added
+_core:
+  default_config_hash: Nms9yoCCdIi8GmePlchxii7oWT7kABc13UF4G6I3W8c
 id: message.group_member_added.default
 targetEntityType: message
 bundle: group_member_added
@@ -17,32 +20,42 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_group_content:
+    type: entity_reference_autocomplete
     weight: 12
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_group_label:
+    type: string_textfield
     weight: 13
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
+  field_related_space:
+    type: entity_reference_autocomplete
+    weight: 14
     region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
-    '#group': advanced
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
+    '#group': advanced
 hidden: {  }

--- a/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_member_removed.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_form_display.message.group_member_removed.default.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.message.group_member_removed.field_group_label
+    - field.field.message.group_member_removed.field_related_space
     - message.template.group_member_removed
+_core:
+  default_config_hash: dHj0dyD5fSWFHBFIj3j66JSM3Mq6I8h_liFdnYk28wg
 id: message.group_member_removed.default
 targetEntityType: message
 bundle: group_member_removed
@@ -16,22 +19,32 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_group_label:
+    type: string_textfield
     weight: 11
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
+  field_related_space:
+    type: entity_reference_autocomplete
+    weight: 12
     region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
-    '#group': advanced
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
+    '#group': advanced
 hidden: {  }

--- a/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_content_created.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_content_created.default.yml
@@ -3,26 +3,37 @@ status: true
 dependencies:
   config:
     - field.field.message.group_content_created.field_group_content
+    - field.field.message.group_content_created.field_related_space
     - message.template.group_content_created
   module:
     - user
+_core:
+  default_config_hash: n210nev18vUeyrECR2Rqxr7Gqkw-AyFgkB6wtp9ku30
 id: message.group_content_created.default
 targetEntityType: message
 bundle: group_content_created
 mode: default
 content:
   field_group_content:
-    weight: 1
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
+    weight: 1
+    region: content
+  field_related_space:
     type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
     region: content
   partial_0:
-    weight: 0
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_content_updated.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_content_updated.default.yml
@@ -3,26 +3,37 @@ status: true
 dependencies:
   config:
     - field.field.message.group_content_updated.field_group_content
+    - field.field.message.group_content_updated.field_related_space
     - message.template.group_content_updated
   module:
     - user
+_core:
+  default_config_hash: 790Q4j_j1c8rGazI2n-pG7TYu4G597Gbp12MKCVKuSU
 id: message.group_content_updated.default
 targetEntityType: message
 bundle: group_content_updated
 mode: default
 content:
   field_group_content:
-    weight: 1
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
+    weight: 1
+    region: content
+  field_related_space:
     type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
     region: content
   partial_0:
-    weight: 0
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_member_added.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_member_added.default.yml
@@ -4,34 +4,45 @@ dependencies:
   config:
     - field.field.message.group_member_added.field_group_content
     - field.field.message.group_member_added.field_group_label
+    - field.field.message.group_member_added.field_related_space
     - message.template.group_member_added
   module:
     - user
+_core:
+  default_config_hash: MlUA4dalTUfmcq0Wybo6hrQgKbQSjYYeqtWrVG94IP8
 id: message.group_member_added.default
 targetEntityType: message
 bundle: group_member_added
 mode: default
 content:
   field_group_content:
-    weight: 1
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 1
     region: content
   field_group_label:
-    weight: 2
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 2
+    region: content
+  field_related_space:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
     region: content
   partial_0:
-    weight: 0
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_member_removed.default.yml
+++ b/modules/living_spaces_activity/config/install/core.entity_view_display.message.group_member_removed.default.yml
@@ -3,26 +3,37 @@ status: true
 dependencies:
   config:
     - field.field.message.group_member_removed.field_group_label
+    - field.field.message.group_member_removed.field_related_space
     - message.template.group_member_removed
   module:
     - user
+_core:
+  default_config_hash: OxXUDamjN-y_FLRxQKpVQaCWMRdm9yUxtIvVigAWjwE
 id: message.group_member_removed.default
 targetEntityType: message
 bundle: group_member_removed
 mode: default
 content:
   field_group_label:
-    weight: 1
+    type: string
     label: above
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
+    region: content
+  field_related_space:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
     region: content
   partial_0:
-    weight: 0
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/modules/living_spaces_activity/config/install/field.field.message.group_content_created.field_related_space.yml
+++ b/modules/living_spaces_activity/config/install/field.field.message.group_content_created.field_related_space.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_related_space
+    - group.type.chat_counseling
+    - group.type.circle
+    - group.type.department
+    - group.type.living_space
+    - group.type.mail_counseling
+    - group.type.on_site_counseling
+    - group.type.project_space
+    - group.type.telephone_counseling
+    - message.template.group_content_created
+id: message.group_content_created.field_related_space
+field_name: field_related_space
+entity_type: message
+bundle: group_content_created
+label: 'Related Space'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      chat_counseling: chat_counseling
+      circle: circle
+      department: department
+      mail_counseling: mail_counseling
+      on_site_counseling: on_site_counseling
+      project_space: project_space
+      living_space: living_space
+      telephone_counseling: telephone_counseling
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: chat_counseling
+field_type: entity_reference

--- a/modules/living_spaces_activity/config/install/field.field.message.group_content_updated.field_related_space.yml
+++ b/modules/living_spaces_activity/config/install/field.field.message.group_content_updated.field_related_space.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_related_space
+    - group.type.chat_counseling
+    - group.type.circle
+    - group.type.department
+    - group.type.living_space
+    - group.type.mail_counseling
+    - group.type.on_site_counseling
+    - group.type.project_space
+    - group.type.telephone_counseling
+    - message.template.group_content_updated
+id: message.group_content_updated.field_related_space
+field_name: field_related_space
+entity_type: message
+bundle: group_content_updated
+label: 'Related Space'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      chat_counseling: chat_counseling
+      circle: circle
+      department: department
+      mail_counseling: mail_counseling
+      on_site_counseling: on_site_counseling
+      project_space: project_space
+      living_space: living_space
+      telephone_counseling: telephone_counseling
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: chat_counseling
+field_type: entity_reference

--- a/modules/living_spaces_activity/config/install/field.field.message.group_member_added.field_related_space.yml
+++ b/modules/living_spaces_activity/config/install/field.field.message.group_member_added.field_related_space.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_related_space
+    - group.type.chat_counseling
+    - group.type.circle
+    - group.type.department
+    - group.type.living_space
+    - group.type.mail_counseling
+    - group.type.on_site_counseling
+    - group.type.project_space
+    - group.type.telephone_counseling
+    - message.template.group_member_added
+id: message.group_member_added.field_related_space
+field_name: field_related_space
+entity_type: message
+bundle: group_member_added
+label: 'Related Space'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      chat_counseling: chat_counseling
+      circle: circle
+      department: department
+      mail_counseling: mail_counseling
+      on_site_counseling: on_site_counseling
+      project_space: project_space
+      living_space: living_space
+      telephone_counseling: telephone_counseling
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: chat_counseling
+field_type: entity_reference

--- a/modules/living_spaces_activity/config/install/field.field.message.group_member_removed.field_related_space.yml
+++ b/modules/living_spaces_activity/config/install/field.field.message.group_member_removed.field_related_space.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_related_space
+    - group.type.chat_counseling
+    - group.type.circle
+    - group.type.department
+    - group.type.living_space
+    - group.type.mail_counseling
+    - group.type.on_site_counseling
+    - group.type.project_space
+    - group.type.telephone_counseling
+    - message.template.group_member_removed
+id: message.group_member_removed.field_related_space
+field_name: field_related_space
+entity_type: message
+bundle: group_member_removed
+label: 'Related Space'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      chat_counseling: chat_counseling
+      circle: circle
+      department: department
+      mail_counseling: mail_counseling
+      on_site_counseling: on_site_counseling
+      project_space: project_space
+      living_space: living_space
+      telephone_counseling: telephone_counseling
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: chat_counseling
+field_type: entity_reference

--- a/modules/living_spaces_activity/config/install/field.storage.message.field_related_space.yml
+++ b/modules/living_spaces_activity/config/install/field.storage.message.field_related_space.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+    - message
+id: message.field_related_space
+field_name: field_related_space
+entity_type: message
+type: entity_reference
+settings:
+  target_type: group
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/living_spaces_activity/config/rewrite/views.view.message.yml
+++ b/modules/living_spaces_activity/config/rewrite/views.view.message.yml
@@ -7,10 +7,13 @@ dependencies:
     - user.role.authenticated
   module:
     - group
+    - living_spaces_activity
     - message
     - message_ui
     - node
     - user
+_core:
+  default_config_hash: GKrcfaIe9qBlUC4cSTPci6aze8glF3EohYpBrN0chic
 id: message
 label: Message
 module: views
@@ -20,120 +23,12 @@ base_table: message_field_data
 base_field: mid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'overview messages'
-      cache:
-        type: none
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 25
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            message_bulk_form_1: message_bulk_form_1
-            mid: mid
-            template: template
-            get_text: get_text
-            uid: uid
-            created: created
-          info:
-            message_bulk_form_1:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            mid:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            template:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-medium
-            get_text:
-              sortable: false
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-medium
-            created:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-          default: mid
-          empty_table: false
-      row:
-        type: fields
+      title: Message
       fields:
         message_bulk_form_1:
           id: message_bulk_form_1
@@ -142,6 +37,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          plugin_id: bulk_form
           label: 'Message operations bulk form'
           exclude: false
           alter:
@@ -187,8 +84,7 @@ display:
           include_exclude: include
           selected_actions:
             - message_delete_action
-          entity_type: message
-          plugin_id: bulk_form
+            - message_delete_action
         mid:
           id: mid
           table: message_field_data
@@ -196,6 +92,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: mid
+          plugin_id: field
           label: 'Message ID'
           exclude: false
           alter:
@@ -252,9 +151,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: mid
-          plugin_id: field
         template:
           id: template
           table: message_field_data
@@ -262,6 +158,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: template
+          plugin_id: field
           label: 'Message template'
           exclude: false
           alter:
@@ -317,9 +216,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: message
-          entity_field: template
-          plugin_id: field
         get_text:
           id: get_text
           table: message
@@ -327,6 +223,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          plugin_id: get_text
           label: 'Message text'
           exclude: false
           alter:
@@ -368,8 +266,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: message
-          plugin_id: get_text
         uid:
           id: uid
           table: message_field_data
@@ -377,6 +273,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: uid
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -432,9 +331,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: message
-          entity_field: uid
-          plugin_id: field
         created:
           id: created
           table: message_field_data
@@ -442,6 +338,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: created
+          plugin_id: date
           label: 'Published date'
           exclude: false
           alter:
@@ -486,15 +385,66 @@ display:
           date_format: fallback
           custom_date_format: ''
           timezone: ''
-          entity_type: message
-          entity_field: created
-          plugin_id: date
         message_ui_contextual_links:
           id: message_ui_contextual_links
           table: message
           field: message_ui_contextual_links
           entity_type: message
           label: Operations
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'overview messages'
+      cache:
+        type: none
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No messages created yet'
+            format: basic_html
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         template:
           id: template
@@ -503,6 +453,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: template
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -513,6 +466,8 @@ display:
             description: ''
             use_operator: false
             operator: template_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: template
             required: false
             remember: false
@@ -522,8 +477,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -536,27 +489,80 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: message
-          entity_field: template
-          plugin_id: bundle
-      sorts: {  }
-      title: Message
-      header: {  }
-      footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'No messages created yet'
-            format: basic_html
-          plugin_id: text
+      filter_groups:
+        operator: AND
+        groups: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            message_bulk_form_1: message_bulk_form_1
+            mid: mid
+            template: template
+            get_text: get_text
+            uid: uid
+            created: created
+          default: mid
+          info:
+            message_bulk_form_1:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            mid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            template:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            get_text:
+              sortable: false
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         field_group_content:
           id: field_group_content
@@ -565,27 +571,25 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_group_content: Group content'
-          required: false
           plugin_id: standard
-      arguments: {  }
+          required: false
+      header: {  }
+      footer: {  }
       display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups: {  }
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -594,33 +598,32 @@ display:
         type: tab
         title: Message
         description: ''
-        parent: system.admin_content
         weight: 0
-        context: '0'
         menu_name: admin
+        parent: system.admin_content
+        context: '0'
       tab_options:
         type: none
         title: ''
         description: ''
         weight: 0
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false
   space_activity:
-    display_plugin: block
     id: space_activity
     display_title: 'Space activity'
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: Activity
       fields:
         created:
           id: created
@@ -629,6 +632,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: created
+          plugin_id: date
           label: ''
           exclude: false
           alter:
@@ -670,6 +676,9 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          date_format: fallback
+          custom_date_format: ''
+          timezone: ''
           click_sort_column: value
           type: timestamp
           settings:
@@ -686,12 +695,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: 0
-          date_format: fallback
-          custom_date_format: ''
-          timezone: ''
-          entity_type: message
-          entity_field: created
-          plugin_id: date
         get_text:
           id: get_text
           table: message
@@ -699,6 +702,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          plugin_id: get_text
           label: ''
           exclude: false
           alter:
@@ -741,22 +746,118 @@ display:
           empty_zero: false
           hide_alter_empty: true
           delta: null
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 5
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: message_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: message
-          plugin_id: get_text
-      defaults:
-        fields: false
-        style: false
-        row: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        empty: false
-        pager: false
-        use_ajax: false
-        arguments: false
-        title: false
-        relationships: false
-        query: false
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        gid:
+          id: gid
+          table: group_content_field_data
+          field: gid
+          relationship: field_group_content
+          group_type: group
+          admin_label: ''
+          entity_type: group_content
+          entity_field: gid
+          plugin_id: group_id
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: group_id_from_url
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+        field_space_target_id:
+          id: field_space_target_id
+          table: node__field_space
+          field: field_space_target_id
+          relationship: field_page
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: group_id_from_url
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -766,121 +867,29 @@ display:
       row:
         type: fields
         options: {  }
-      filters: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-      sorts:
-        created:
-          id: created
-          table: message_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: ''
-          granularity: second
-          entity_type: message
-          entity_field: created
-          plugin_id: date
-      empty: {  }
-      pager:
-        type: mini
+      query:
+        type: views_query
         options:
-          items_per_page: 5
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-      use_ajax: true
-      arguments:
-        gid:
-          id: gid
-          table: group_content_field_data
-          field: gid
-          relationship: field_group_content
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: group_id_from_url
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          entity_type: group_content
-          entity_field: gid
-          plugin_id: group_id
-        field_space_target_id:
-          id: field_space_target_id
-          table: node__field_space
-          field: field_space_target_id
-          relationship: field_page
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: group_id_from_url
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
-      title: Activity
-      block_description: Activity
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: null
+          contextual_filters_or: true
+      defaults:
+        empty: false
+        query: false
+        title: false
+        use_ajax: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        sorts: false
+        arguments: false
+        filters: false
+        filter_groups: false
       relationships:
         field_group_content:
           id: field_group_content
@@ -889,8 +898,8 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_group_content: Group content'
-          required: false
           plugin_id: standard
+          required: false
         field_page:
           id: field_page
           table: message__field_page
@@ -898,17 +907,12 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_page: Content'
-          required: false
           plugin_id: standard
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: null
-          contextual_filters_or: true
+          required: false
+      use_ajax: true
+      display_description: ''
+      display_extenders: {  }
+      block_description: Activity
     cache_metadata:
       max-age: -1
       contexts:
@@ -920,13 +924,12 @@ display:
         - user.permissions
       tags: {  }
   user_activity:
-    display_plugin: block
     id: user_activity
     display_title: 'User activity'
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: Activity
       fields:
         created:
           id: created
@@ -935,6 +938,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: created
+          plugin_id: date
           label: ''
           exclude: false
           alter:
@@ -976,6 +982,9 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          date_format: fallback
+          custom_date_format: ''
+          timezone: ''
           click_sort_column: value
           type: timestamp
           settings:
@@ -992,12 +1001,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: 0
-          date_format: fallback
-          custom_date_format: ''
-          timezone: ''
-          entity_type: message
-          entity_field: created
-          plugin_id: date
         get_text:
           id: get_text
           table: message
@@ -1005,6 +1008,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          plugin_id: get_text
           label: ''
           exclude: false
           alter:
@@ -1047,22 +1052,152 @@ display:
           empty_zero: false
           hide_alter_empty: true
           delta: null
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 5
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: message_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: message
-          plugin_id: get_text
-      defaults:
-        fields: false
-        style: false
-        row: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        empty: false
-        pager: false
-        use_ajax: false
-        arguments: false
-        title: false
-        relationships: false
-        query: false
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        gid:
+          id: gid
+          table: group_content_field_data
+          field: gid
+          relationship: field_group_content
+          group_type: group
+          admin_label: ''
+          entity_type: group_content
+          entity_field: gid
+          plugin_id: group_id
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: living_spaces_group_joined_spaces
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        field_space_target_id:
+          id: field_space_target_id
+          table: node__field_space
+          field: field_space_target_id
+          relationship: field_page
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: living_spaces_group_joined_spaces
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        field_related_space_target_id:
+          id: field_related_space_target_id
+          table: message__field_related_space
+          field: field_related_space_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: living_spaces_group_joined_spaces
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -1072,121 +1207,29 @@ display:
       row:
         type: fields
         options: {  }
-      filters: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-      sorts:
-        created:
-          id: created
-          table: message_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: ''
-          granularity: second
-          entity_type: message
-          entity_field: created
-          plugin_id: date
-      empty: {  }
-      pager:
-        type: mini
+      query:
+        type: views_query
         options:
-          items_per_page: 5
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-      use_ajax: true
-      arguments:
-        gid:
-          id: gid
-          table: group_content_field_data
-          field: gid
-          relationship: field_group_content
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: living_spaces_group_joined_spaces
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: true
-          not: false
-          entity_type: group_content
-          entity_field: gid
-          plugin_id: group_id
-        field_space_target_id:
-          id: field_space_target_id
-          table: node__field_space
-          field: field_space_target_id
-          relationship: field_page
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: living_spaces_group_joined_spaces
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: true
-          not: false
-          plugin_id: numeric
-      title: Activity
-      block_description: Activity
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: null
+          contextual_filters_or: true
+      defaults:
+        empty: false
+        query: false
+        title: false
+        use_ajax: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        sorts: false
+        arguments: false
+        filters: false
+        filter_groups: false
       relationships:
         field_group_content:
           id: field_group_content
@@ -1195,8 +1238,8 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_group_content: Group content'
-          required: false
           plugin_id: standard
+          required: false
         field_page:
           id: field_page
           table: message__field_page
@@ -1204,17 +1247,12 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_page: Content'
-          required: false
           plugin_id: standard
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: null
-          contextual_filters_or: true
+          required: false
+      use_ajax: true
+      display_description: ''
+      display_extenders: {  }
+      block_description: Activity
     cache_metadata:
       max-age: -1
       contexts:
@@ -1225,36 +1263,12 @@ display:
         - user.permissions
       tags: {  }
   user_notifications:
-    display_plugin: block
     id: user_notifications
     display_title: 'User notifications'
+    display_plugin: block
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       title: 'User notifications'
-      defaults:
-        title: false
-        style: false
-        row: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        relationships: false
-        arguments: false
-        pager: false
-        use_ajax: false
-        footer: false
-        empty: false
-        access: false
-      style:
-        type: living_spaces_activity_notification
-        options:
-          class: show
-      row:
-        type: fields
-        options: {  }
       fields:
         get_text:
           id: get_text
@@ -1263,6 +1277,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          plugin_id: get_text
           label: ''
           exclude: false
           alter:
@@ -1305,8 +1321,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           delta: null
-          entity_type: message
-          plugin_id: get_text
         created:
           id: created
           table: message_field_data
@@ -1314,6 +1328,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: created
+          plugin_id: date
           label: ''
           exclude: false
           alter:
@@ -1355,6 +1372,9 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          date_format: fallback
+          custom_date_format: ''
+          timezone: ''
           click_sort_column: value
           type: timestamp_ago
           settings:
@@ -1371,12 +1391,71 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: 0
-          date_format: fallback
-          custom_date_format: ''
-          timezone: ''
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 5
+      access:
+        type: role
+        options:
+          role:
+            authenticated: authenticated
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: message_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: message
           entity_field: created
           plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        uid:
+          id: uid
+          table: message_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: message
+          entity_field: uid
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: current_user
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         is_read:
           id: is_read
@@ -1385,6 +1464,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: is_read
+          plugin_id: boolean
           operator: '='
           value: '0'
           group: 1
@@ -1415,9 +1497,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: message
-          entity_field: is_read
-          plugin_id: boolean
         template:
           id: template
           table: message_field_data
@@ -1425,6 +1504,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: message
+          entity_field: template
+          plugin_id: bundle
           operator: in
           value:
             group_member_added: group_member_added
@@ -1458,81 +1540,37 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: message
-          entity_field: template
-          plugin_id: bundle
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        created:
-          id: created
-          table: message_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: ''
-          granularity: second
-          entity_type: message
-          entity_field: created
-          plugin_id: date
+      style:
+        type: living_spaces_activity_notification
+        options:
+          class: show
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        empty: false
+        access: false
+        title: false
+        use_ajax: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        sorts: false
+        arguments: false
+        filters: false
+        filter_groups: false
+        footer: false
       relationships: {  }
-      arguments:
-        uid:
-          id: uid
-          table: message_field_data
-          field: uid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: current_user
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          entity_type: message
-          entity_field: uid
-          plugin_id: numeric
-      pager:
-        type: some
-        options:
-          items_per_page: 5
-          offset: 0
       use_ajax: true
+      display_description: ''
       footer: {  }
-      empty: {  }
-      access:
-        type: role
-        options:
-          role:
-            authenticated: authenticated
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/living_spaces_activity/living_spaces_activity.module
+++ b/modules/living_spaces_activity/living_spaces_activity.module
@@ -103,6 +103,7 @@ function living_spaces_activity_form_message_template_form_alter(&$form, FormSta
  */
 function living_spaces_activity_group_content_insert(GroupContentInterface $content) {
   // @todo add check is content type is among field target bundles.
+  $space = \Drupal::request()->query->get('space');
   if ('group_membership' == $content->getContentPlugin()->getBaseId()) {
     /** @var \Drupal\message\Entity\Message $message */
     $message = \Drupal::entityTypeManager()->getStorage('message')->create([
@@ -110,6 +111,7 @@ function living_spaces_activity_group_content_insert(GroupContentInterface $cont
       'uid' => $content->getEntity()->id(),
       'field_group_content' => $content->id(),
       'field_group_label' => $content->getGroup()->label(),
+      'field_related_space' => ['target_id' => $space],
     ]);
     $message->save();
   }
@@ -118,6 +120,7 @@ function living_spaces_activity_group_content_insert(GroupContentInterface $cont
     $message = \Drupal::entityTypeManager()->getStorage('message')->create([
       'template' => 'group_content_created',
       'field_group_content' => $content->id(),
+      'field_related_space' => ['target_id' => $space],
     ]);
     $message->save();
   }
@@ -128,11 +131,13 @@ function living_spaces_activity_group_content_insert(GroupContentInterface $cont
  */
 function living_spaces_activity_group_content_update(GroupContentInterface $content) {
   // @todo add check is content type is among field target bundles.
+  $space = \Drupal::request()->query->get('space');
   if ('group_membership' != $content->getContentPlugin()->getBaseId()) {
     /** @var \Drupal\message\Entity\Message $message */
     $message = \Drupal::entityTypeManager()->getStorage('message')->create([
       'template' => 'group_content_updated',
       'field_group_content' => $content->id(),
+      'field_related_space' => ['target_id' => $space],
     ]);
     $message->save();
   }
@@ -143,12 +148,14 @@ function living_spaces_activity_group_content_update(GroupContentInterface $cont
  */
 function living_spaces_activity_group_content_delete(GroupContentInterface $content) {
   // @todo add check is content type is among field target bundles.
+  $space = \Drupal::request()->query->get('space');
   if ('group_membership' == $content->getContentPlugin()->getBaseId() && $content->getEntity()) {
     /** @var \Drupal\message\Entity\Message $message */
     $message = \Drupal::entityTypeManager()->getStorage('message')->create([
       'template' => 'group_member_removed',
       'uid' => $content->getEntity()->id(),
       'field_group_label' => $content->getGroup()->label(),
+      'field_related_space' => ['target_id' => $space],
     ]);
     $message->save();
   }

--- a/modules/living_spaces_page/config/install/core.entity_form_display.message.page_created.default.yml
+++ b/modules/living_spaces_page/config/install/core.entity_form_display.message.page_created.default.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.message.page_created.field_page
+    - field.field.message.page_created.field_related_space
     - message.template.page_created
+_core:
+  default_config_hash: ZUIy2v121OmMBOuNjuBneQkVqyCV4tF1aJ6zfMa6Tt8
 id: message.page_created.default
 targetEntityType: message
 bundle: page_created
@@ -16,24 +19,34 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_page:
+    type: entity_reference_autocomplete
     weight: 12
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_related_space:
     type: entity_reference_autocomplete
+    weight: 13
     region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
-    '#group': advanced
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
+    '#group': advanced
 hidden: {  }

--- a/modules/living_spaces_page/config/install/core.entity_form_display.message.page_updated.default.yml
+++ b/modules/living_spaces_page/config/install/core.entity_form_display.message.page_updated.default.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.message.page_updated.field_page
+    - field.field.message.page_updated.field_related_space
     - message.template.page_updated
+_core:
+  default_config_hash: HeRAywKnEBKaK83ciTfCq-PpQ2AcnWLfPTsPHS3yDsE
 id: message.page_updated.default
 targetEntityType: message
 bundle: page_updated
@@ -16,24 +19,34 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_page:
+    type: entity_reference_autocomplete
     weight: 12
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_related_space:
     type: entity_reference_autocomplete
+    weight: 13
     region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
-    '#group': advanced
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
+    '#group': advanced
 hidden: {  }

--- a/modules/living_spaces_page/config/install/core.entity_view_display.message.page_created.default.yml
+++ b/modules/living_spaces_page/config/install/core.entity_view_display.message.page_created.default.yml
@@ -3,26 +3,37 @@ status: true
 dependencies:
   config:
     - field.field.message.page_created.field_page
+    - field.field.message.page_created.field_related_space
     - message.template.page_created
   module:
     - user
+_core:
+  default_config_hash: qdXC8c7Wa2RJaX7OJf1AOZ7uB8AbdBecU-xlw4hVbYQ
 id: message.page_created.default
 targetEntityType: message
 bundle: page_created
 mode: default
 content:
   field_page:
-    weight: 1
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
+    weight: 1
+    region: content
+  field_related_space:
     type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
     region: content
   partial_0:
-    weight: 0
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/modules/living_spaces_page/config/install/core.entity_view_display.message.page_updated.default.yml
+++ b/modules/living_spaces_page/config/install/core.entity_view_display.message.page_updated.default.yml
@@ -3,26 +3,37 @@ status: true
 dependencies:
   config:
     - field.field.message.page_updated.field_page
+    - field.field.message.page_updated.field_related_space
     - message.template.page_updated
   module:
     - user
+_core:
+  default_config_hash: Btu_pFXb3g1LAWRj9UQU_JUcm5h62_8MLZvBOrp76IE
 id: message.page_updated.default
 targetEntityType: message
 bundle: page_updated
 mode: default
 content:
   field_page:
-    weight: 1
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
+    weight: 1
+    region: content
+  field_related_space:
     type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
     region: content
   partial_0:
-    weight: 0
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/modules/living_spaces_page/config/install/field.field.message.page_created.field_related_space.yml
+++ b/modules/living_spaces_page/config/install/field.field.message.page_created.field_related_space.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_related_space
+    - group.type.chat_counseling
+    - group.type.circle
+    - group.type.department
+    - group.type.living_space
+    - group.type.mail_counseling
+    - group.type.on_site_counseling
+    - group.type.project_space
+    - group.type.telephone_counseling
+    - message.template.page_created
+id: message.page_created.field_related_space
+field_name: field_related_space
+entity_type: message
+bundle: page_created
+label: 'Related Space'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      chat_counseling: chat_counseling
+      circle: circle
+      department: department
+      mail_counseling: mail_counseling
+      on_site_counseling: on_site_counseling
+      project_space: project_space
+      living_space: living_space
+      telephone_counseling: telephone_counseling
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: chat_counseling
+field_type: entity_reference

--- a/modules/living_spaces_page/config/install/field.field.message.page_updated.field_related_space.yml
+++ b/modules/living_spaces_page/config/install/field.field.message.page_updated.field_related_space.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_related_space
+    - group.type.chat_counseling
+    - group.type.circle
+    - group.type.department
+    - group.type.living_space
+    - group.type.mail_counseling
+    - group.type.on_site_counseling
+    - group.type.project_space
+    - group.type.telephone_counseling
+    - message.template.page_updated
+id: message.page_updated.field_related_space
+field_name: field_related_space
+entity_type: message
+bundle: page_updated
+label: 'Related Space'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:group'
+  handler_settings:
+    target_bundles:
+      chat_counseling: chat_counseling
+      circle: circle
+      department: department
+      mail_counseling: mail_counseling
+      on_site_counseling: on_site_counseling
+      project_space: project_space
+      living_space: living_space
+      telephone_counseling: telephone_counseling
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: chat_counseling
+field_type: entity_reference

--- a/modules/living_spaces_page/living_spaces_page.module
+++ b/modules/living_spaces_page/living_spaces_page.module
@@ -125,10 +125,11 @@ function living_spaces_page_node_access(NodeInterface $entity, $operation, Accou
 function living_spaces_page_node_insert(NodeInterface $entity) {
   if ('page' == $entity->bundle()) {
     living_spaces_page_attach_page($entity);
-
+    $space = \Drupal::request()->query->get('space');
     $message = \Drupal::entityTypeManager()->getStorage('message')->create([
       'template' => 'page_created',
       'field_page' => $entity->id(),
+      'field_related_space' => ['target_id' => $space],
     ]);
     $message->save();
   }
@@ -140,10 +141,11 @@ function living_spaces_page_node_insert(NodeInterface $entity) {
 function living_spaces_page_node_update(NodeInterface $entity) {
   if ('page' == $entity->bundle()) {
     living_spaces_page_attach_page($entity);
-
+    $space = \Drupal::request()->query->get('space');
     $message = \Drupal::entityTypeManager()->getStorage('message')->create([
       'template' => 'page_updated',
       'field_page' => $entity->id(),
+      'field_related_space' => ['target_id' => $space],
     ]);
     $message->save();
   }


### PR DESCRIPTION
… 'group_content_created', 'group_content_updated', 'group_member_added', 'group_member_removed', 'page_created', 'page_updated'. Prepopulated this field with current space id when the message is created. Removed broken handler of contextual filter from view message.user_activity, added the new one based on the 'field_related_space' field.