### PR TITLE
Ref #41196 Removed the permission 'access living spaces privacy' from…

### DIFF
--- a/modules/living_spaces_group_privacy/config/rewrite/user.role.client_admin.yml
+++ b/modules/living_spaces_group_privacy/config/rewrite/user.role.client_admin.yml
@@ -1,2 +1,0 @@
-permissions:
-  - 'access living spaces privacy'

--- a/modules/living_spaces_group_privacy/config/rewrite/user.role.office_manager.yml
+++ b/modules/living_spaces_group_privacy/config/rewrite/user.role.office_manager.yml
@@ -1,2 +1,0 @@
-permissions:
-  - 'access living spaces privacy'

--- a/modules/living_spaces_group_privacy/living_spaces_group_privacy.module
+++ b/modules/living_spaces_group_privacy/living_spaces_group_privacy.module
@@ -103,23 +103,8 @@ function living_spaces_group_privacy_form_group_form_alter(&$form, FormStateInte
       $access = $group->hasPermission('access living spaces privacy', $user);
     }
   }
-  /** @var \Drupal\group\Entity\GroupInterface $group */
-  $group = $form_state->getFormObject()->getEntity();
-  $bundles = [
-    'department',
-    'chat_counseling',
-    'mail_counseling',
-    'telephone_counseling',
-    'on_site_counseling',
-  ];
-  if (in_array($group->bundle(), $bundles)) {
-    $default_value = 'private';
-    if (isset($form['living_space_privacy']['widget']['#options'][$default_value])) {
-      $form['living_space_privacy']['widget']['#default_value'] = $default_value;
-    }
-  }
 
-  if (!$access && $group) {
+  if (!$access && $group = $form_state->getFormObject()->getEntity()) {
     $access = $group->hasPermission('access living spaces privacy', $user);
   }
 

--- a/modules/living_spaces_group_privacy/living_spaces_group_privacy.module
+++ b/modules/living_spaces_group_privacy/living_spaces_group_privacy.module
@@ -103,8 +103,23 @@ function living_spaces_group_privacy_form_group_form_alter(&$form, FormStateInte
       $access = $group->hasPermission('access living spaces privacy', $user);
     }
   }
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $form_state->getFormObject()->getEntity();
+  $bundles = [
+    'department',
+    'chat_counseling',
+    'mail_counseling',
+    'telephone_counseling',
+    'on_site_counseling',
+  ];
+  if (in_array($group->bundle(), $bundles)) {
+    $default_value = 'private';
+    if (isset($form['living_space_privacy']['widget']['#options'][$default_value])) {
+      $form['living_space_privacy']['widget']['#default_value'] = $default_value;
+    }
+  }
 
-  if (!$access && $group = $form_state->getFormObject()->getEntity()) {
+  if (!$access && $group) {
     $access = $group->hasPermission('access living spaces privacy', $user);
   }
 

--- a/modules/living_spaces_intranet/living_spaces_intranet.module
+++ b/modules/living_spaces_intranet/living_spaces_intranet.module
@@ -341,3 +341,17 @@ function living_spaces_intranet_form_user_form_alter(&$form, FormStateInterface 
   }
 
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function living_spaces_intranet_form_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $form_state->getFormObject()->getEntity();
+  if ('department' == $group->bundle()) {
+    $default_value = 'private';
+    if (isset($form['living_space_privacy']['widget']['#options'][$default_value])) {
+      $form['living_space_privacy']['widget']['#default_value'] = $default_value;
+    }
+  }
+}


### PR DESCRIPTION
… roles office_manager and client_admin. Set the default value 'private' for the 'living_space_privacy' field the the spaces of type 'department', 'chat_counseling', 'mail_counseling','telephone_counseling', 'on_site_counseling'.