### PR TITLE
Ref #45339 

### DIFF
--- a/modules/living_spaces_users/living_spaces_users.module
+++ b/modules/living_spaces_users/living_spaces_users.module
@@ -300,26 +300,3 @@ function living_spaces_users_entity_base_field_info_alter(&$fields, EntityTypeIn
     $fields['mail']->addConstraint('UserEmailEmpty');
   }
 }
-
-/**
- * Implements hook_ENTITY_TYPE_insert().
- */
-function living_spaces_users_user_insert(EntityInterface $entity) {
-  /** @var \Drupal\user\UserInterface $entity */
-  if (empty($entity->getEmail())) {
-    $current_user = Drupal::currentUser();
-    if ($email = $current_user->getEmail()) {
-      $params['account'] = $entity;
-      $op = 'register_admin_created';
-      $site_mail = \Drupal::config('system.site')->get('mail_notification');
-      if (empty($site_mail)) {
-        $site_mail = \Drupal::config('system.site')->get('mail');
-      }
-      if (empty($site_mail)) {
-        $site_mail = ini_get('sendmail_from');
-      }
-      \Drupal::service('plugin.manager.mail')->mail('user', $op, $email, $current_user->getPreferredLangcode(), $params, $site_mail);
-    }
-
-  }
-}

--- a/modules/living_spaces_users/living_spaces_users.module
+++ b/modules/living_spaces_users/living_spaces_users.module
@@ -8,6 +8,8 @@
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -73,6 +75,9 @@ function living_spaces_users_form_user_form_alter(&$form, FormStateInterface $fo
     }
 
     $form['account']['pass']['#access'] = $access;
+    if ($access && $form_state->get('user_pass_reset')) {
+      $form['account']['pass']['#required'] = TRUE;
+    }
   }
 }
 
@@ -285,4 +290,36 @@ function living_spaces_users_living_spaces_breadcrumbs_info(RouteMatchInterface 
   }
 
   return $applies;
+}
+
+/**
+ * Implements hook_entity_base_field_info_alter().
+ */
+function living_spaces_users_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
+  if ('user' == $entity_type->id() && !empty($fields['mail'])) {
+    $fields['mail']->addConstraint('UserEmailEmpty');
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function living_spaces_users_user_insert(EntityInterface $entity) {
+  /** @var \Drupal\user\UserInterface $entity */
+  if (empty($entity->getEmail())) {
+    $current_user = Drupal::currentUser();
+    if ($email = $current_user->getEmail()) {
+      $params['account'] = $entity;
+      $op = 'register_admin_created';
+      $site_mail = \Drupal::config('system.site')->get('mail_notification');
+      if (empty($site_mail)) {
+        $site_mail = \Drupal::config('system.site')->get('mail');
+      }
+      if (empty($site_mail)) {
+        $site_mail = ini_get('sendmail_from');
+      }
+      \Drupal::service('plugin.manager.mail')->mail('user', $op, $email, $current_user->getPreferredLangcode(), $params, $site_mail);
+    }
+
+  }
 }

--- a/modules/living_spaces_users/src/Plugin/Validation/Constraint/UserEmailEmptyConstraint.php
+++ b/modules/living_spaces_users/src/Plugin/Validation/Constraint/UserEmailEmptyConstraint.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\living_spaces_users\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the submitted to create user does not have email.
+ *
+ * @Constraint(
+ *   id = "UserEmailEmpty",
+ *   label = @Translation("User Email Is Empty", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class UserEmailEmptyConstraint extends Constraint {
+  public $creatorHasNoEmail = 'The creator does not have email, the user email is required.';
+}

--- a/modules/living_spaces_users/src/Plugin/Validation/Constraint/UserEmailEmptyConstraintValidator.php
+++ b/modules/living_spaces_users/src/Plugin/Validation/Constraint/UserEmailEmptyConstraintValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\living_spaces_users\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the UserEmailEmpty constraint.
+ */
+class UserEmailEmptyConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Creates a new UserEmailEmptyConstraintValidator instance.
+   */
+  public function __construct(AccountInterface $current_user) {
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($value, Constraint $constraint) {
+    if (empty($value->value) && !$this->currentUser->getEmail()) {
+      $this->context->addViolation(($constraint->creatorHasNoEmail));
+    }
+  }
+
+}


### PR DESCRIPTION
https://rm5.dom.de/issues/45339
Prevented saving the OTP confirmation form with an empty password. Improved the case of creating a user with a regular 'Add user' admin form. Added constraint to check the new user without email address before creating, raising the error if the creator does not have email as well. Send the email to the creator if the user does not have the email.