### PR TITLE
Ref #45905

### DIFF
--- a/modules/living_spaces_intranet/living_spaces_intranet.module
+++ b/modules/living_spaces_intranet/living_spaces_intranet.module
@@ -328,6 +328,8 @@ function living_spaces_intranet_form_user_employee_form_alter(&$form, FormStateI
     $form['account']['mail']['#element_validate'] = ['_living_spaces_intranet_user_employee_email_validate'];
   }
 
+  $form['#attributes']['data-user-info-from-browser'] = FALSE;
+
   $form['account']['pass']['#required'] = FALSE;
   $form['account']['pass']['#access'] = FALSE;
 


### PR DESCRIPTION
https://rm5.dom.de/issues/45905
Restricted the auto-populating fields from the localStorage of the browser in the user employee create form for all user roles.