### PR TITLE
Ref #45827

### DIFF
--- a/config/install/core.entity_form_display.user.user.employee.yml
+++ b/config/install/core.entity_form_display.user.user.employee.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.user.user.user_picture
     - image.style.thumbnail
   module:
+    - autocomplete_deluxe
     - image
     - profile
     - user
@@ -24,35 +25,52 @@ content:
     third_party_settings: {  }
   chat_enabled:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
-      display_label: true
+      display_label: false
     third_party_settings: {  }
   contact_data_profiles:
-    type: profile_form
-    weight: 2
-    region: content
-    settings:
-      form_mode: default
-    third_party_settings: {  }
-  core_profiles:
-    type: profile_form
-    weight: 1
-    region: content
-    settings:
-      form_mode: default
-    third_party_settings: {  }
-  employee_data_profiles:
     type: profile_form
     weight: 3
     region: content
     settings:
       form_mode: default
     third_party_settings: {  }
+  core_profiles:
+    type: profile_form
+    weight: 2
+    region: content
+    settings:
+      form_mode: default
+    third_party_settings: {  }
+  employee_data_profiles:
+    type: profile_form
+    weight: 4
+    region: content
+    settings:
+      form_mode: default
+    third_party_settings: {  }
+  joined_spaces:
+    type: autocomplete_deluxe
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      size: 60
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+    third_party_settings: {  }
   user_picture:
     type: image_image
-    weight: 4
+    weight: 5
     region: content
     settings:
       progress_indicator: throbber

--- a/modules/living_spaces_group/config/install/views.view.groups.yml
+++ b/modules/living_spaces_group/config/install/views.view.groups.yml
@@ -1,12 +1,18 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - group.type.circle
   module:
     - group
+    - living_spaces_group
     - living_spaces_group_privacy
     - living_spaces_subgroup
     - user
     - views_field_view
+  enforced:
+    module:
+      - living_spaces_group
 id: groups
 label: Groups
 module: views
@@ -16,120 +22,12 @@ base_table: groups_field_data
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Default
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'manage living spaces'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 25
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            label: label
-            living_spaces_subgroup_parent_field: living_spaces_subgroup_parent_field
-            type: type
-            uid: uid
-            living_spaces_group_privacy_field: living_spaces_group_privacy_field
-            operations: operations
-          info:
-            label:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            living_spaces_subgroup_parent_field:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            living_spaces_group_privacy_field:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: label
-          empty_table: false
-      row:
-        type: fields
+      title: Groups
       fields:
         label:
           id: label
@@ -138,6 +36,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: label
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -193,9 +94,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: label
-          plugin_id: field
         living_spaces_subgroup_parent_field:
           id: living_spaces_subgroup_parent_field
           table: groups_field_data
@@ -203,6 +101,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          plugin_id: living_spaces_subgroup_parent_field
           label: Hierarchy
           exclude: false
           alter:
@@ -245,8 +145,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           all: 1
-          entity_type: group
-          plugin_id: living_spaces_subgroup_parent_field
         type:
           id: type
           table: groups_field_data
@@ -254,6 +152,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          entity_field: type
+          plugin_id: field
           label: Type
           exclude: false
           alter:
@@ -309,9 +210,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: group
-          entity_field: type
-          plugin_id: field
         uid:
           id: uid
           table: groups_field_data
@@ -319,6 +217,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          entity_field: uid
+          plugin_id: field
           label: Manager
           exclude: false
           alter:
@@ -374,9 +275,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: group
-          entity_field: uid
-          plugin_id: field
         living_spaces_group_privacy_field:
           id: living_spaces_group_privacy_field
           table: groups_field_data
@@ -384,6 +282,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          plugin_id: living_spaces_group_privacy_field
           label: Access
           exclude: false
           alter:
@@ -425,8 +325,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: group
-          plugin_id: living_spaces_group_privacy_field
         operations:
           id: operations
           table: groups
@@ -434,6 +332,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          plugin_id: entity_operations
           label: Actions
           exclude: false
           alter:
@@ -476,8 +376,47 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: false
-          entity_type: group
-          plugin_id: entity_operations
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'manage living spaces'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         type:
           id: type
@@ -486,6 +425,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -519,9 +461,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: group
-          entity_field: type
-          plugin_id: bundle
         label:
           id: label
           table: groups_field_data
@@ -529,6 +468,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          entity_field: label
+          plugin_id: string
           operator: word
           value: ''
           group: 1
@@ -562,9 +504,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: group
-          entity_field: label
-          plugin_id: string
         living_spaces_group_is_living:
           id: living_spaces_group_is_living
           table: groups_field_data
@@ -572,6 +511,8 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Living space'
+          entity_type: group
+          plugin_id: living_spaces_group_is_living
           operator: in
           value: {  }
           group: 1
@@ -603,20 +544,85 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: group
-          plugin_id: living_spaces_group_is_living
-      sorts: {  }
-      title: Groups
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            label: label
+            living_spaces_subgroup_parent_field: living_spaces_subgroup_parent_field
+            type: type
+            uid: uid
+            living_spaces_group_privacy_field: living_spaces_group_privacy_field
+            operations: operations
+          default: label
+          info:
+            label:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            living_spaces_subgroup_parent_field:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            living_spaces_group_privacy_field:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -626,24 +632,535 @@ display:
         - url.query_args
         - user.permissions
       tags: {  }
-  preferred_spaces:
-    display_plugin: entity_reference
-    id: preferred_spaces
-    display_title: 'Preferred spaces'
-    position: 1
+  circles:
+    id: circles
+    display_title: Circles
+    display_plugin: page
+    position: 2
     display_options:
-      display_extenders: { }
-      display_description: ''
-      style:
-        type: entity_reference
+      title: Circles
+      fields:
+        id:
+          id: id
+          table: groups_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: id
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: label
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        uid:
+          id: uid
+          table: groups_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: uid
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        living_spaces_group_privacy_field:
+          id: living_spaces_group_privacy_field
+          table: groups_field_data
+          field: living_spaces_group_privacy_field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          plugin_id: living_spaces_group_privacy_field
+          label: Access
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: view
+          label: Inherited
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view: groups
+          display: inherited
+          arguments: '{{ raw_fields.id }}'
+        operations:
+          id: operations
+          table: groups
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          plugin_id: entity_operations
+          label: Actions
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+      access:
+        type: perm
         options:
-          search_fields:
-            label: label
-            living_spaces_subgroup_parent_field: '0'
-            type: '0'
-            uid: '0'
-            living_spaces_group_privacy_field: '0'
-            operations: '0'
+          perm: 'access circles overview'
+      filters:
+        type:
+          id: type
+          table: groups_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            circle: circle
+          group: 1
+          exposed: false
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: label
+          plugin_id: string
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: label_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: label_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: label
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        living_spaces_group_privacy_filter:
+          id: living_spaces_group_privacy_filter
+          table: groups_field_data
+          field: living_spaces_group_privacy_field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: living_space_privacy
+          plugin_id: string
+          operator: '='
+          value: public
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        access: false
+        title: false
+        relationships: false
+        fields: false
+        filters: false
+        filter_groups: false
+      relationships: {  }
+      display_description: ''
+      display_extenders: {  }
+      path: admin/group/circles
+      menu:
+        type: tab
+        title: Circles
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: system.admin_group
+        context: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  inherited:
+    id: inherited
+    display_title: Inherited
+    display_plugin: block
+    position: 3
+    display_options:
       fields:
         label:
           id: label
@@ -652,6 +1169,179 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: label
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      access:
+        type: none
+        options: {  }
+      sorts:
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: label
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        circles_target_id:
+          id: circles_target_id
+          table: group__circles
+          field: circles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: circles
+          plugin_id: numeric
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        access: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+      tags: {  }
+  preferred_spaces:
+    id: preferred_spaces
+    display_title: 'Preferred spaces'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      fields:
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: label
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -698,7 +1388,7 @@ display:
           settings:
             link_to_entity: false
           group_column: value
-          group_columns: { }
+          group_columns: {  }
           group_rows: true
           delta_limit: 0
           delta_offset: 0
@@ -707,9 +1397,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: label
-          plugin_id: field
         type:
           id: type
           table: groups_field_data
@@ -717,6 +1404,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: group
+          entity_field: type
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -763,7 +1453,7 @@ display:
           settings:
             link: false
           group_column: target_id
-          group_columns: { }
+          group_columns: {  }
           group_rows: true
           delta_limit: 0
           delta_offset: 0
@@ -772,17 +1462,46 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: group
-          entity_field: type
-          plugin_id: field
-      defaults:
-        fields: false
-        filters: false
-        filter_groups: false
-        access: false
-        relationships: false
-        arguments: false
-        group_by: false
+      access:
+        type: none
+        options: {  }
+      arguments:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: gc__user
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: uid
+          plugin_id: user_uid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: current_user
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         living_spaces_group_is_living:
           id: living_spaces_group_is_living
@@ -791,8 +1510,10 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Living space'
+          entity_type: group
+          plugin_id: living_spaces_group_is_living
           operator: in
-          value: { }
+          value: {  }
           group: 1
           exposed: false
           expose:
@@ -802,7 +1523,7 @@ display:
             use_operator: false
             operator: ''
             operator_limit_selection: false
-            operator_list: { }
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -820,14 +1541,22 @@ display:
             multiple: false
             remember: false
             default_group: All
-            default_group_multiple: { }
-            group_items: { }
-          entity_type: group
-          plugin_id: living_spaces_group_is_living
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            label: label
+            living_spaces_subgroup_parent_field: '0'
+            type: '0'
+            uid: '0'
+            living_spaces_group_privacy_field: '0'
+            operations: '0'
       row:
         type: entity_reference
         options:
@@ -837,9 +1566,14 @@ display:
             type: type
           separator: ' - '
           hide_empty: false
-      access:
-        type: none
-        options: { }
+      defaults:
+        access: false
+        group_by: false
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
       relationships:
         group_content_id:
           id: group_content_id
@@ -848,13 +1582,13 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Group membership'
+          entity_type: group
+          plugin_id: group_to_group_content
           required: true
           group_content_plugins:
             group_membership: group_membership
             'group_node:discussion_post': '0'
             'group_node:page': '0'
-          entity_type: group
-          plugin_id: group_to_group_content
         gc__user:
           id: gc__user
           table: group_content_field_data
@@ -862,49 +1596,14 @@ display:
           relationship: group_content_id
           group_type: group
           admin_label: 'Group content User'
+          entity_type: group_content
+          plugin_id: group_content_to_entity
           required: false
           group_content_plugins:
             group_membership: group_membership
-          entity_type: group_content
-          plugin_id: group_content_to_entity
-      arguments:
-        uid:
-          id: uid
-          table: users_field_data
-          field: uid
-          relationship: gc__user
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: current_user
-          default_argument_options: { }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: { }
-          break_phrase: false
-          not: false
-          entity_type: user
-          entity_field: uid
-          plugin_id: user_uid
       group_by: false
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -912,4 +1611,268 @@ display:
         - 'languages:language_interface'
         - url
         - user
-      tags: { }
+      tags: {  }
+  spaces_to_join:
+    id: spaces_to_join
+    display_title: 'Spaces to join'
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      fields:
+        label:
+          id: label
+          table: groups_field_data
+          field: label
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: label
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: groups_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: type
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      access:
+        type: none
+        options: {  }
+      arguments: {  }
+      filters:
+        living_spaces_group_is_living:
+          id: living_spaces_group_is_living
+          table: groups_field_data
+          field: living_spaces_group_is_living
+          relationship: none
+          group_type: group
+          admin_label: 'Living space'
+          entity_type: group
+          plugin_id: living_spaces_group_is_living
+          operator: in
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        living_spaces_group_user_joined_spaces:
+          id: living_spaces_group_user_joined_spaces
+          table: groups_field_data
+          field: living_spaces_group_user_joined_spaces
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          plugin_id: living_spaces_group_user_joined_spaces
+          operator: '='
+          value:
+            - 'yes'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          group_in_user_joined_spaces: ''
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            label: label
+            living_spaces_subgroup_parent_field: '0'
+            type: '0'
+            uid: '0'
+            living_spaces_group_privacy_field: '0'
+            operations: '0'
+      row:
+        type: entity_reference
+        options:
+          default_field_elements: true
+          inline:
+            label: label
+            type: type
+          separator: ' - '
+          hide_empty: false
+      defaults:
+        access: false
+        group_by: false
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      relationships: {  }
+      group_by: false
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }

--- a/modules/living_spaces_group/living_spaces_group.module
+++ b/modules/living_spaces_group/living_spaces_group.module
@@ -24,6 +24,8 @@ use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Link;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_ENTITY_TYPE_access().
@@ -252,11 +254,64 @@ function living_spaces_group_entity_base_field_info(EntityTypeInterface $entity_
     $fields['joined_spaces'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Spaces'))
       ->setSetting('target_type', 'group')
+      ->setSetting('handler', 'views')
+      ->setSetting('handler_settings', [
+        'view' => [
+          'view_name' => 'groups',
+          'display_name' => 'spaces_to_join',
+        ],
+      ])
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
-      ->setTranslatable(FALSE);
+      ->setTranslatable(FALSE)
+      ->setDisplayConfigurable('form', TRUE);
   }
 
   return $fields;
+}
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function living_spaces_group_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ('groups' == $view->id() && 'spaces_to_join' == $view->current_display) {
+    $current_user = Drupal::currentUser();
+    if ($current_user->hasPermission('add members to any space')) {
+      foreach ($query->where as &$condition_group) {
+        foreach ($condition_group['conditions'] as $key => $condition) {
+          if ($condition['field'] == 'groups_field_data.id' && $condition['operator'] == 'IN') {
+            unset($condition_group['conditions'][$key]);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function living_spaces_group_form_user_employee_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $current_user = Drupal::currentUser();
+  if (
+    isset($form['joined_spaces']) &&
+    !$current_user->hasPermission('add members to any space') &&
+    !$current_user->hasPermission('add members to administered space')
+  ) {
+    $form['joined_spaces']['#access'] = FALSE;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function living_spaces_group_user_insert(UserInterface $user) {
+  $space_ids = array_column($user->get('joined_spaces')->getValue(), 'target_id');
+  $groups = \Drupal::entityTypeManager()->getStorage('group')->loadMultiple($space_ids);
+
+  /** @var Drupal\group\Entity\GroupInterface $group */
+  foreach ($groups as $group) {
+    $group->addMember($user);
+  }
 }
 
 /**


### PR DESCRIPTION
https://rm5.dom.de/issues/45827
Added the display 'spaces_to_join' of the view 'groups' to get options for joined spaces. Added hook for this display to show all spaces if the user has permission 'add members to any space', otherwise show only groups where the user is a member.

Fixed the field definition for 'joined_spaces', added configurable form, and set source handler to the display 'spaces_to_join' of the view 'groups'.

Added field 'joined_spaces' to the Employee create form if the user has permissions 'add members to any space' or 'add members to administered space'.

Added newly created user as a member to each space in the field 'joined_spaces'.