### PR TITLE
Ref #46109

### DIFF
--- a/modules/living_spaces_circles/src/Controller/LivingSpacesCirclesAutoCompleteController.php
+++ b/modules/living_spaces_circles/src/Controller/LivingSpacesCirclesAutoCompleteController.php
@@ -17,17 +17,15 @@ class LivingSpacesCirclesAutoCompleteController extends ControllerBase {
    */
   public function autocomplete(Request $request) {
     $results = [];
-    $input = $request->query->get('q');
-
-    if (!$input) {
-      return new JsonResponse($results);
-    }
+    $input = trim($request->query->get('q'));
 
     $group_manager = $this->entityTypeManager()->getStorage('group');
 
     $query = $group_manager->getQuery();
     $query->condition('type', 'circle');
-    $query->condition('label', '%' . Xss::filter($input) . '%', 'LIKE');
+    if ($input) {
+      $query->condition('label', '%' . Xss::filter($input) . '%', 'LIKE');
+    }
     $query->condition('status', TRUE);
     $query->range(0, 10);
 

--- a/modules/living_spaces_group/config/install/views.view.members.yml
+++ b/modules/living_spaces_group/config/install/views.view.members.yml
@@ -6,8 +6,12 @@ dependencies:
     - group.content_type.living_space-group_membership
   module:
     - group
+    - living_spaces_group
     - role_delegation
     - user
+  enforced:
+    module:
+      - living_spaces_group
 id: members
 label: Members
 module: views
@@ -680,7 +684,6 @@ display:
             add_remove_admin: add_remove_admin
             block_user: block_user
             unblock_user: unblock_user
-      sorts:
         circles_target_id:
           id: circles_target_id
           table: group__circles
@@ -690,12 +693,63 @@ display:
           admin_label: ''
           entity_type: group
           entity_field: circles
-          plugin_id: standard
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: ''
-          exposed: false
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      sorts:
         id:
           id: id
           table: groups_field_data
@@ -705,6 +759,21 @@ display:
           admin_label: ''
           entity_type: group
           entity_field: id
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: gc__user
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
           plugin_id: standard
           order: ASC
           expose:
@@ -752,48 +821,6 @@ display:
               trainee_intern: '0'
               office_manager: '0'
               assistant_to_the_office_manager: '0'
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        langcode:
-          id: langcode
-          table: groups_field_data
-          field: langcode
-          relationship: gid
-          group_type: group
-          admin_label: ''
-          entity_type: group
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value:
-            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/modules/living_spaces_group/living_spaces_group.module
+++ b/modules/living_spaces_group/living_spaces_group.module
@@ -471,10 +471,19 @@ function living_spaces_group_living_spaces_group_actions_info($names_only = TRUE
 
   $current_is_admin = \Drupal::service('living_spaces_group.manager')->isUserSpaceAdmin($current_user, $space);
 
+  $allow_only_lower = FALSE;
+  if (!$current_is_admin && $space->hasPermission('administer members', $current_user)) {
+    $allow_only_lower = living_spaces_users_get_user_level($current_user) <= living_spaces_users_get_user_level($user);
+  }
+
   if (
     $space->getOwnerId() !== $user->id()
     && $current_user->id() != $user->id()
-    && ($current_is_admin || $space->hasPermission('manage space members', $current_user))
+    && (
+      $current_is_admin ||
+      $allow_only_lower ||
+      $space->hasPermission('manage space members', $current_user)
+    )
   ) {
     $links['remove_from_space'] = [
       '#type' => 'link',


### PR DESCRIPTION
https://rm5.dom.de/issues/46109
Fixed the LivingSpacesCirclesAutoCompleteController to get available circles if any input was provided in the Inherit tab of spaces.

Allowed the editing members with lower weights to the user with permission of 'administer members' in the space.

Fixed the showing members of groups in the display 'members_by_role' of the view 'members'.