### PR TITLE
Ref #47471 Hide tabs 'group.version_history' and 'entity.version_hist…

### DIFF
--- a/modules/living_spaces_group/living_spaces_group.module
+++ b/modules/living_spaces_group/living_spaces_group.module
@@ -654,6 +654,9 @@ function living_spaces_group_menu_local_tasks_alter(&$data, $route_name, Refinab
     'group.content',
     'views_view:view.group_nodes.page_1',
     'devel.entities:group.devel_tab',
+    // Groups and circles revisions.
+    'group.version_history',
+    'entity.version_history:group.version_history',
     // Groups and circles list.
     'group.settings',
     'living_spaces_group_privacy.privacy_form',


### PR DESCRIPTION
…ory:group.version_history' in the groups view.
https://rm5.dom.de/issues/47471